### PR TITLE
Sorting jobs by completed date, or started date, else run id

### DIFF
--- a/src/main/kotlin/com/dsoftware/ghmanager/api/model/JobModel.kt
+++ b/src/main/kotlin/com/dsoftware/ghmanager/api/model/JobModel.kt
@@ -1,12 +1,17 @@
 package com.dsoftware.ghmanager.api.model
 
 import com.fasterxml.jackson.annotation.JsonFormat
-import java.util.Date
+import com.intellij.util.containers.SortedList
+import java.util.*
 
 data class JobsList(
     val total_count: Int,
-    val jobs: List<Job>
-)
+    val jobs: SortedList<Job>
+) {
+    constructor(total_count: Int, jobs: Iterable<Job>) : this(
+        total_count,
+        SortedList(Job::compareTo).apply { addAll(jobs) })
+}
 
 /**
  * Information of a job execution in a workflow run
@@ -70,9 +75,18 @@ data class Job(
     val runnerGroupId: Long?,
     /* The name of the runner group to which this job has been assigned. (If a runner hasn't yet been assigned, this will be null.) */
     val runnerGroupName: String?
-) {
+) : Comparable<Job> {
     override fun equals(other: Any?): Boolean = (other != null) && (other is Job) && (other.id == this.id)
     override fun hashCode(): Int = this.id.hashCode()
+
+    /**
+     * Compare jobs by their completedAt, or startedAt (the newest first), or by id runId both dates are null
+     * @param other The other job to compare to
+     */
+    override fun compareTo(other: Job): Int =
+        other.completedAt?.compareTo(this.completedAt)
+            ?: other.startedAt?.compareTo(this.startedAt)
+            ?: other.runId.compareTo(this.runId)
 }
 
 /**

--- a/src/main/kotlin/com/dsoftware/ghmanager/api/model/RunModel.kt
+++ b/src/main/kotlin/com/dsoftware/ghmanager/api/model/RunModel.kt
@@ -39,9 +39,21 @@ data class WorkflowRun(
     val head_commit: GitHubHeadCommit,
     val repository: GitHubRepository,
     val pull_requests: List<PullRequest>? = emptyList(),
-)
+) : Comparable<WorkflowRun> {
+
+    /**
+     * Compare workflows by their updated_at, or created_at (the newest first), or by id run_number both dates are null
+     * @param other The other workflow to compare to
+     */
+    override fun compareTo(other: WorkflowRun): Int {
+        return other.updated_at?.compareTo(this.updated_at)
+            ?: other.created_at?.compareTo(this.created_at)
+            ?: other.run_number.compareTo(this.run_number)
+    }
+}
+
 data class GitHubRepository(
-    val id:Int,
+    val id: Int,
     val pulls_url: String,
     val html_url: String,
 )

--- a/src/main/kotlin/com/dsoftware/ghmanager/data/GHListLoaderBase.kt
+++ b/src/main/kotlin/com/dsoftware/ghmanager/data/GHListLoaderBase.kt
@@ -10,12 +10,13 @@ import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.util.EventDispatcher
 import com.intellij.util.concurrency.annotations.RequiresEdt
+import com.intellij.util.containers.SortedList
 import org.jetbrains.plugins.github.pullrequest.data.GHListLoader
 import org.jetbrains.plugins.github.util.NonReusableEmptyProgressIndicator
 import java.util.concurrent.CompletableFuture
 import kotlin.properties.Delegates
 
-abstract class GHListLoaderBase<T>(
+abstract class GHListLoaderBase<T : Comparable<T>>(
     private val progressManager: ProgressManager
 ) : Disposable {
 
@@ -40,7 +41,7 @@ abstract class GHListLoaderBase<T>(
     protected val dataEventDispatcher = EventDispatcher.create(GHListLoader.ListDataListener::class.java)
 
     @get:RequiresEdt
-    val loadedData = ArrayList<T>()
+    val loadedData = SortedList<T> { a, b -> a.compareTo(b) }
 
     @RequiresEdt
     open fun canLoadMore() = !loading && (error != null)

--- a/src/main/kotlin/com/dsoftware/ghmanager/data/WorkflowRunListLoader.kt
+++ b/src/main/kotlin/com/dsoftware/ghmanager/data/WorkflowRunListLoader.kt
@@ -44,7 +44,6 @@ class WorkflowRunListLoader(
         addDataListener(this, object : GHListLoader.ListDataListener {
             override fun onDataAdded(startIdx: Int) {
                 val loadedData = this@WorkflowRunListLoader.loadedData
-                loadedData.sortWith { o1, o2 -> o2.run_number.compareTo(o1.run_number) }
                 listModel.replaceAll(loadedData)
             }
 


### PR DESCRIPTION
Linked to this issue: https://github.com/cunla/ghactions-manager/issues/60#issue-1443544514

Sorting runs by *completion/update date* if not null, else *start date* if not null, else *run id*.
Using *SortedList*, and *Comparable* extension on **Job** & **WorkflowRun** classes

A button to trigger the order, and/or the variable to sort by would be amazing, but I do not master Kotlin & Jetbrain API enough to do it :smiling_face_with_tear: 