### PR TITLE
Missing branches and missing update on branch filer changes

### DIFF
--- a/src/main/kotlin/com/dsoftware/ghmanager/data/WorkflowRunListLoader.kt
+++ b/src/main/kotlin/com/dsoftware/ghmanager/data/WorkflowRunListLoader.kt
@@ -112,15 +112,20 @@ class WorkflowRunListLoader(
     }
 
     private fun updateBranches(indicator: ProgressIndicator) {
-        val request = GithubApiRequests.Repos.Branches.get(
-            repositoryCoordinates.serverPath,
-            repositoryCoordinates.repositoryPath.owner,
-            repositoryCoordinates.repositoryPath.repository
-        )
-        LOG.info("Calling ${request.url}")
-        val response = requestExecutor.execute(indicator, request)
         repoBranches.clear()
-        repoBranches.addAll(response.items.map { it.name })
+        var pageNumber = 1;
+        do {
+            val request = GithubApiRequests.Repos.Branches.get(
+                    repositoryCoordinates.serverPath,
+                    repositoryCoordinates.repositoryPath.owner,
+                    repositoryCoordinates.repositoryPath.repository,
+                    GithubRequestPagination(pageNumber)
+            )
+            LOG.info("Calling ${request.url}")
+            val response = requestExecutor.execute(indicator, request)
+            repoBranches.addAll(response.items.map { it.name })
+            pageNumber++;
+        } while (response.hasNext)
     }
 
     override fun dispose() {

--- a/src/main/kotlin/com/dsoftware/ghmanager/data/WorkflowRunListLoader.kt
+++ b/src/main/kotlin/com/dsoftware/ghmanager/data/WorkflowRunListLoader.kt
@@ -98,17 +98,24 @@ class WorkflowRunListLoader(
     }
 
     private fun updateCollaborators(indicator: ProgressIndicator) {
-        val request = GithubApiRequests.Repos.Collaborators.get(
-            repositoryCoordinates.serverPath,
-            repositoryCoordinates.repositoryPath.owner,
-            repositoryCoordinates.repositoryPath.repository
-        )
-        val response = requestExecutor.execute(indicator, request)
-        LOG.info("Calling ${request.url}")
         repoCollaborators.clear()
-        repoCollaborators.addAll(
-            response.items.map { GHUser(it.nodeId, it.login, it.htmlUrl, it.avatarUrl ?: "", null) }
-        )
+        var pageNumber = 1;
+        do {
+            val request = GithubApiRequests.Repos.Collaborators.get(
+                repositoryCoordinates.serverPath,
+                repositoryCoordinates.repositoryPath.owner,
+                repositoryCoordinates.repositoryPath.repository,
+                GithubRequestPagination(pageNumber)
+            )
+
+            LOG.info("Calling ${request.url}")
+            val response = requestExecutor.execute(indicator, request)
+
+            repoCollaborators.addAll(
+                response.items.map { GHUser(it.nodeId, it.login, it.htmlUrl, it.avatarUrl ?: "", null) }
+            )
+            pageNumber++;
+        } while (response.hasNext)
     }
 
     private fun updateBranches(indicator: ProgressIndicator) {

--- a/src/main/kotlin/com/dsoftware/ghmanager/data/WorkflowRunSelectionContext.kt
+++ b/src/main/kotlin/com/dsoftware/ghmanager/data/WorkflowRunSelectionContext.kt
@@ -93,7 +93,7 @@ class WorkflowRunSelectionContext internal constructor(
 
     fun resetAllData() {
         runsListLoader.reset()
-        runsListLoader.loadMore()
+        runsListLoader.loadMore(true)
         dataLoader.invalidateAllData()
     }
 

--- a/src/main/kotlin/com/dsoftware/ghmanager/ui/panels/WorkflowRunListLoaderPanel.kt
+++ b/src/main/kotlin/com/dsoftware/ghmanager/ui/panels/WorkflowRunListLoaderPanel.kt
@@ -230,6 +230,7 @@ internal class WorkflowRunListLoaderPanel(
             runListComponent.emptyText.text = "No workflow run loaded. "
             runListComponent.emptyText.appendSecondaryText("Refresh", SimpleTextAttributes.LINK_PLAIN_ATTRIBUTES) {
                 workflowRunsLoader.reset()
+                workflowRunsLoader.loadMore(true)
             }
             infoPanel.setInfo(
                 when {


### PR DESCRIPTION
This PR tries to fix two issues:

1. In large repositories that contains more than 30 branches not all available branches will be shown in the branch filter control
2. By clearing the selected branch filter the workflow run list will not be updated immediately. Also not by clicking on the "Refresh" action.